### PR TITLE
Update mattermost-plugin-gmail 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,15 @@
 ### Latest Release
 
-##### v0.1.0-test
+##### v0.1.1
 
-Initial release meant for demonstration of features and testing.
+- Persisting state and user information after plugin restarts
+- A gmail ID can now be connected to by multiple Mattermost users. However, one Mattermost user can be connected to only one gmail ID at a time
+- New sub-command: `subscriptions` to display labels currently subscribed by the user
+- Minor changes to display statements and fixed behaviour of disconnect command
 
 
 ### Previous Releases
 
-_Currently, there are no previous releases_
+##### v0.1.0-test
+
+- Initial release meant for demonstration of features and testing.

--- a/plugin.json
+++ b/plugin.json
@@ -5,7 +5,7 @@
     "homepage_url": "https://github.com/abdulsmapara/mattermost-plugin-gmail/blob/master/README.md",
     "release_notes_url": "https://github.com/abdulsmapara/mattermost-plugin-gmail/blob/master/CHANGELOG.md",
     "support_url": "https://github.com/abdulsmapara/mattermost-plugin-gmail/issues",
-    "version": "0.1.0",
+    "version": "0.1.1",
     "min_server_version": "5.19.0",
     "server": {
         "executables": {

--- a/server/constants.go
+++ b/server/constants.go
@@ -15,6 +15,7 @@ const (
 		"* `/gmail import thread <thread-message-id>` - Import a complete Gmail thread (conversation) using ID of any mail in the thread\n" +
 		"* `/gmail subscribe <optional-label-ids>` - Subscribe to get notifications from the Gmail Bot for the labels mentioned. Mention the label IDs in comma-separated fashion from the list: INBOX, CATEGORY_PERSONAL, CATEGORY_SOCIAL, CATEGORY_PROMOTIONS, CATEGORY_UPDATES, CATEGORY_FORUMS. The default label is INBOX.\n" +
 		"* `/gmail unsubscribe <optional-label-ids>` - Unsubscribe from the mentioned labels (should be comma-separated). If none is mentioned, you'll be unsubscribed from all the label IDs. It might take a few minutes for the effect to take place.\n" +
+		"* `/gmail subscriptions` - Display label IDs currently subscribed to\n" +
 		"* `/gmail help` - Display help about this plugin"
 )
 
@@ -29,3 +30,15 @@ const (
 const (
 	emailScope = "https://www.googleapis.com/auth/userinfo.email"
 )
+
+// label IDs supported
+// Note: supportedLabelIDs used as set data structure
+var supportedLabelIDs = map[string]int{
+	/* Label */            /* Any valid int*/
+	"INBOX":               1,
+	"CATEGORY_PROMOTIONS": 2,
+	"CATEGORY_PERSONAL":   3,
+	"CATEGORY_SOCIAL":     4,
+	"CATEGORY_UPDATES":    5,
+	"CATEGORY_FORUMS":     6,
+}

--- a/server/manifest.go
+++ b/server/manifest.go
@@ -15,8 +15,9 @@ const manifestStr = `
   "id": "mattermost-plugin-gmail",
   "name": "Mattermost Gmail Bot",
   "description": "Gmail Integration for Mattermost",
-  "homepage_url": "https://github.com/abdulsmapara/mattermost-plugin-gmail",
+  "homepage_url": "https://github.com/abdulsmapara/mattermost-plugin-gmail/blob/master/README.md",
   "support_url": "https://github.com/abdulsmapara/mattermost-plugin-gmail/issues",
+  "release_notes_url": "https://github.com/abdulsmapara/mattermost-plugin-gmail/blob/master/CHANGELOG.md",
   "version": "0.1.0",
   "min_server_version": "5.19.0",
   "server": {

--- a/server/manifest.go
+++ b/server/manifest.go
@@ -18,7 +18,7 @@ const manifestStr = `
   "homepage_url": "https://github.com/abdulsmapara/mattermost-plugin-gmail/blob/master/README.md",
   "support_url": "https://github.com/abdulsmapara/mattermost-plugin-gmail/issues",
   "release_notes_url": "https://github.com/abdulsmapara/mattermost-plugin-gmail/blob/master/CHANGELOG.md",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "min_server_version": "5.19.0",
   "server": {
     "executables": {

--- a/server/plugin.go
+++ b/server/plugin.go
@@ -22,8 +22,6 @@ type Plugin struct {
 	// configuration is the active plugin configuration. Consult getConfiguration and
 	// setConfiguration for usage.
 	configuration *configuration
-
-	mailNotificationDetails subscriptionDetails
 }
 
 // OnActivate is invoked when the plugin is activated. If an error is returned, the plugin will be terminated.
@@ -43,7 +41,7 @@ func (p *Plugin) OnActivate() error {
 		Trigger:          commandGmail,
 		AutoComplete:     true,
 		AutoCompleteHint: "[command]",
-		AutoCompleteDesc: "Available Commands: connect, import, help",
+		AutoCompleteDesc: "Available Commands: connect, disconnect, subscribe, unsubscribe, import, subscriptions, help",
 	}); err != nil {
 		errorMessage := "failed to register command " + commandGmail
 		p.API.LogError(errorMessage, "err", err.Error())
@@ -58,7 +56,7 @@ func (p *Plugin) OnActivate() error {
 		Description: "Created by Mattermost Gmail Plugin.",
 	}
 
-	// Ensure the bot. If not present create an Issue Resolver bot
+	// Ensure the bot. If not present create Gmail bot
 	gmailBotID, err := p.Helpers.EnsureBot(gmailBot)
 	if err != nil {
 		p.API.LogError("Failed to ensure gmail bot ", "err", err.Error())

--- a/server/utils.go
+++ b/server/utils.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"math"
+	"strconv"
 	"strings"
 	// "github.com/mattermost/mattermost-server/v5/mlog"
 	"github.com/DusanKasan/parsemail"
@@ -19,12 +20,6 @@ import (
 	accessAPI "google.golang.org/api/oauth2/v2" // Package oauth2 provides access to the Google OAuth2 API
 	"google.golang.org/api/option"
 )
-
-type subscriptionDetails struct {
-	UserID    string
-	HistoryID uint64
-	LabelIDs  []string
-}
 
 // CreateBotDMPost creates a post as gmail bot to the user directly
 func (p *Plugin) CreateBotDMPost(userID, message string) (string, error) {
@@ -103,7 +98,8 @@ func (p *Plugin) getGmailService(userID string) (*gmail.Service, error) {
 	var token oauth2.Token
 
 	tokenInByte, appErr := p.API.KVGet(userID + "gmailToken")
-	if appErr != nil {
+	if appErr != nil || tokenInByte == nil {
+		p.API.LogError("Error occured while getting gmail token", "err", appErr)
 		return nil, errors.New(appErr.DetailedError)
 	}
 
@@ -141,15 +137,166 @@ func (p *Plugin) getOAuthService(userID string) (*accessAPI.Service, error) {
 
 // getGmailID retrieves the gmail ID of the user
 func (p *Plugin) getGmailID(userID string) (string, error) {
+	gmailID, kvErr := p.API.KVGet(userID + "gmailID")
+	if kvErr == nil && gmailID != nil {
+		return string(gmailID), nil
+	}
 	oauth2Service, err := p.getOAuthService(userID)
 	if err != nil {
 		return "", err
 	}
 	userInfo, err := oauth2Service.Userinfo.Get().Do()
-	if err != nil {
+	if err != nil || userInfo == nil {
 		return "", err
 	}
+	p.API.KVSet(userID+"gmailID", []byte(userInfo.Email))
 	return userInfo.Email, nil
+}
+
+// addUserForGmail adds a user connected with the given Gmail ID
+func (p *Plugin) addUserForGmail(gmailID string, userID string) error {
+	p.API.LogInfo("Adding user with userID: " + userID + " for gmailID: " + gmailID)
+
+	userIDs, err := p.getUsersForGmail(gmailID)
+	if err != nil {
+		p.API.LogError("Error occured while fetching users connected to a given Gmail ID", "err", err.Error())
+		return err
+	}
+	if userIDs == nil {
+		userIDs = []string{}
+	}
+	userIDs = append(userIDs, userID)
+
+	p.API.KVSet(gmailID+"users", []byte(strings.Join(userIDs, ",")))
+	p.API.LogInfo("User added successfully for the gmail ID")
+
+	return nil
+}
+
+// removeUserForGmail removes user connected with given Gmail ID
+func (p *Plugin) removeUserForGmail(gmailID string, userID string) error {
+	userIDs, err := p.getUsersForGmail(gmailID)
+
+	if err != nil {
+		p.API.LogError("Error occured while fetching users connected to a given Gmail ID", "err", err.Error())
+		return err
+	}
+	if userIDs == nil {
+		p.API.LogError("No user found for gmail ID: " + gmailID)
+		return nil
+	}
+	updatedUserIDs := []string{}
+
+	// TODO: OPTIMIZATION Use set instead of array for storing/updating user IDs
+	for _, existingUserID := range userIDs {
+		if existingUserID != userID {
+			updatedUserIDs = append(updatedUserIDs, existingUserID)
+		}
+	}
+
+	p.API.KVSet(gmailID+"users", []byte(strings.Join(updatedUserIDs, ",")))
+	return nil
+}
+
+// onboardUser onboards user to the plugin when connected to a Gmail account
+func (p *Plugin) onboardUser(userID string, tokenJSON []byte) error {
+
+	err := p.API.KVSet(userID+"gmailToken", tokenJSON)
+	if err != nil {
+		p.API.LogError("Error in setting gmail token", "err", err.Error())
+		return err
+	}
+
+	gmailID, gmailErr := p.getGmailID(userID)
+	if gmailErr != nil {
+		p.API.LogError("Error in getting gmail ID for the user with user ID: "+userID, "err", gmailErr.Error())
+		return gmailErr
+	}
+
+	err = p.API.KVSet(userID+"gmailID", []byte(gmailID))
+	if err != nil {
+		p.API.LogError("Error in setting gmail ID as "+gmailID+" for the user with user ID: "+userID, "err", err.Error())
+		return err
+	}
+
+	gmailErr = p.addUserForGmail(gmailID, userID)
+	if gmailErr != nil {
+		p.API.LogError("Error in adding user with user ID: "+userID+" to list of users connected to gmail ID: "+gmailID, "err", gmailErr.Error())
+		return gmailErr
+	}
+
+	labelErr := p.subscribeToLabels(userID, gmailID, p.getSupportedLabels())
+	if labelErr != nil {
+		p.API.LogError("Error in subscribing user with user ID: "+userID+" to all supported labels", "err", labelErr.Error())
+		return labelErr
+	}
+
+	return nil
+}
+
+// offboardUser off boards user from the plugin when disconnected from Gmail
+func (p *Plugin) offboardUser(userID string) error {
+	p.API.LogInfo("Offboarding user with userID: " + userID)
+
+	gmailID, _ := p.getGmailID(userID)
+
+	err := p.removeUserForGmail(gmailID, userID)
+	if err != nil {
+		return err
+	}
+
+	p.API.KVDelete(userID + "subscriptions")
+
+	p.API.KVDelete(userID + "gmailID")
+
+	p.API.KVDelete(userID + "gmailToken")
+
+	p.API.LogInfo("Offboarding successfully completed for the user")
+
+	return nil
+}
+
+// getUsersForGmail returns array of user IDs connected with the given Gmail ID
+func (p *Plugin) getUsersForGmail(gmailID string) ([]string, error) {
+	users, err := p.API.KVGet(gmailID + "users")
+	if err != nil {
+		return nil, err
+	}
+	if users == nil {
+		return []string{}, nil
+	}
+	return strings.Split(string(users), ","), nil
+}
+
+// updateSubscriptionsOfUser updates subscriptions of the user
+func (p *Plugin) updateSubscriptionsOfUser(userID string, labelIDs []string) error {
+	return p.API.KVSet(userID+"subscriptions", []byte(strings.Join(labelIDs, ",")))
+}
+
+// getSubscriptionsOfUser returns subscriptions of the user
+func (p *Plugin) getSubscriptionsOfUser(userID string) ([]string, error) {
+	subscriptions, err := p.API.KVGet(userID + "subscriptions")
+	return strings.Split(string(subscriptions), ","), err
+}
+
+// removeAllSubscriptionsOfUser
+func (p *Plugin) removeAllSubscriptionsOfUser(userID string) error {
+	return p.API.KVDelete(userID + "subscriptions")
+}
+
+// updateHistoryIDForGmail updates historyID of the user
+func (p *Plugin) updateHistoryIDForUser(historyID uint64, userID string) error {
+	return p.API.KVSet(userID+"historyID", []byte(strconv.Itoa(int(historyID))))
+}
+
+// getHistoryIDForGmail returns history ID of the user
+func (p *Plugin) getHistoryIDForUser(userID string) (uint64, error) {
+	historyID, err := p.API.KVGet(userID + "historyID")
+	if err == nil {
+		histID, err := strconv.Atoi(string(historyID))
+		return uint64(histID), err
+	}
+	return uint64(0), err
 }
 
 // getThreadID generates ID of thread from rfcID of the mail in the thread
@@ -217,7 +364,7 @@ func (p *Plugin) parseMessage(message string) (string, string, string, string, s
 	email, err := parsemail.Parse(reader) // returns Email struct and error
 	if err != nil {
 		// return details from self parsed message
-		p.API.LogInfo("Error in using parsemail package: " + err.Error())
+		p.API.LogError("Error in using parsemail package", "err", err.Error())
 		return "", "", "", "", "", nil, err
 	}
 	year, month, day := email.Date.Date()
@@ -246,7 +393,7 @@ func (p *Plugin) parseMessage(message string) (string, string, string, string, s
 		if html2mdErr == nil {
 			return email.Subject, mailBody, date, fromNames, email.MessageID, attachments, nil
 		}
-		p.API.LogInfo("Error in converting html to markdown: " + html2mdErr.Error())
+		p.API.LogError("Error in converting html to markdown", "err", html2mdErr.Error())
 	}
 
 	return email.Subject, email.TextBody, date, fromNames, email.MessageID, attachments, nil
@@ -255,7 +402,7 @@ func (p *Plugin) parseMessage(message string) (string, string, string, string, s
 func (p *Plugin) getAttachmentDetails(attachment parsemail.Attachment) (string, []byte) {
 	bytesData, err := ioutil.ReadAll(attachment.Data)
 	if err != nil {
-		p.API.LogInfo("Error has occured: " + err.Error())
+		p.API.LogError("Error occured in reading attachments", "err", err.Error())
 		return "", []byte{}
 	}
 	return attachment.Filename, bytesData
@@ -277,7 +424,7 @@ func (p *Plugin) handleMessages(messages []*gmail.Message, channelID string, use
 		base64URLMessage := message.Raw
 		plainTextMessage, err := p.decodeBase64URL(base64URLMessage)
 		if err != nil {
-			p.sendMessageFromBot(channelID, userID, true, "Error: "+err.Error())
+			p.API.LogError("Error occured in decoding base64 URL message", "err", err.Error())
 			return err
 		}
 
@@ -288,7 +435,7 @@ func (p *Plugin) handleMessages(messages []*gmail.Message, channelID string, use
 			sharingInfo = "**Message ID: <" + rfcID + ">**. _(Import in any channel using `/gmail import <mail/thread> <ID>`)_\n\n"
 		}
 		if err != nil {
-			p.sendMessageFromBot(channelID, userID, true, "An error has occured while trying to parse the mail. Please try again later or report to the System Administrator.")
+			p.API.LogError("An error has occured while trying to parse the mail", "err", err.Error())
 			return err
 		}
 		if from == "" {
@@ -301,7 +448,7 @@ func (p *Plugin) handleMessages(messages []*gmail.Message, channelID string, use
 			fileName, fileData := p.getAttachmentDetails(attachment)
 			fileInfo, fileErr := p.API.UploadFile(fileData, channelID, fileName)
 			if fileErr != nil {
-				p.sendMessageFromBot(channelID, userID, true, "Attachment "+fileName+" was not uploaded. Please report this to the System Administrator")
+				p.API.LogError("Attachment "+fileName+" could not be uploaded", "err", err.Error())
 			}
 			fileNameArray = append(fileNameArray, fileName)
 			fileIDArray = append(fileIDArray, fileInfo.Id)
@@ -345,11 +492,62 @@ func (p *Plugin) handleMessages(messages []*gmail.Message, channelID string, use
 				postInfo, err := p.API.CreatePost(post)
 				parentID = postInfo.Id
 				if err != nil {
-					p.sendMessageFromBot(channelID, userID, true, "An error has occured : "+err.Error())
+					p.API.LogError("Could not create post", "err", err.Error())
 					return err
 				}
 			}
 		}
 	}
 	return nil
+}
+
+// subscribeToLabels
+func (p *Plugin) subscribeToLabels(userID string, gmailID string, labelIDs []string) error {
+	gmailService, _ := p.getGmailService(userID)
+	watchRequest := &gmail.WatchRequest{
+		LabelFilterAction: "include",
+		LabelIds:          labelIDs,
+		TopicName:         p.getConfiguration().TopicName,
+	}
+	watchResponse, err := gmailService.Users.Watch(gmailID, watchRequest).Do()
+	if err != nil {
+		p.API.LogError("Could not subscribe user to the supported labels", "err", err.Error())
+		return err
+	}
+	p.updateHistoryIDForUser(uint64(watchResponse.HistoryId), userID)
+	p.updateSubscriptionsOfUser(userID, labelIDs)
+	return nil
+}
+
+// getRelevantMessagesForUser filters messages that have a label the user is subscribed to
+func (p *Plugin) getRelevantMessagesForUser(userID string, messages []*gmail.Message) []*gmail.Message {
+	subscriptions, _ := p.getSubscriptionsOfUser(userID)
+	relevantMessages := []*gmail.Message{}
+	// TODO: OPTIMIZATION
+	messageAdded := false
+	for _, message := range messages {
+		messageAdded = false
+		for _, subscription := range subscriptions {
+			for _, messageLabel := range message.LabelIds {
+				if messageLabel == subscription {
+					relevantMessages = append(relevantMessages, message)
+					messageAdded = true
+					break
+				}
+			}
+			if messageAdded {
+				break
+			}
+		}
+	}
+	return relevantMessages
+}
+
+// getSupportedLabels
+func (p *Plugin) getSupportedLabels() []string {
+	labels := []string{}
+	for label := range supportedLabelIDs {
+		labels = append(labels, label)
+	}
+	return labels
 }


### PR DESCRIPTION
##### v0.1.1

- Persisting state and user information after plugin restarts
- A gmail ID can now be connected to by multiple Mattermost users. However, one Mattermost user can be connected to only one gmail ID at a time
- New sub-command: `subscriptions` to display labels currently subscribed by the user
- Minor changes to display statements and fixed behaviour of disconnect command

Fixes #1 
